### PR TITLE
feat(badge): overridable parameters

### DIFF
--- a/lib/mbta_metro/components/badge.ex
+++ b/lib/mbta_metro/components/badge.ex
@@ -4,8 +4,12 @@ defmodule MbtaMetro.Components.Badge do
   use Phoenix.Component
 
   attr :class, :string, default: ""
-  attr :color, :string, default: "blue"
-  attr :type, :string, required: true
+  attr :color_class, :string, default: "bg-blue-500"
+  attr :font_class, :string, default: "text-sm font-semibold"
+  attr :padding_class, :string
+  attr :rounded_class, :string, default: ""
+  attr :sizing_class, :string
+  attr :type, :string, required: true, values: ["circle", "square"]
 
   slot :inner_block, required: true
 
@@ -18,21 +22,42 @@ defmodule MbtaMetro.Components.Badge do
   end
 
   defp circle(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:padding_class, fn -> "px-0.5 py-1" end)
+      |> assign_new(:sizing_class, fn -> "w-6 h-6" end)
+
     ~H"""
-    <div class={"inline-flex rounded-full bg-#{@color}-500 px-0.5 py-1 w-6 h-6 text-sm font-semibold text-center #{@class}"}>
-      <div class="w-5 flex items-center justify-center margin-auto">
-        <p><%= render_slot(@inner_block) %></p>
-      </div>
+    <div class={[
+      "inline-flex rounded-full items-center justify-center whitespace-nowrap",
+      @color_class,
+      @font_class,
+      @padding_class,
+      @sizing_class,
+      @class
+    ]}>
+      <%= render_slot(@inner_block) %>
     </div>
     """
   end
 
   defp square(assigns) do
+    assigns =
+      assigns
+      |> assign_new(:padding_class, fn -> "px-1" end)
+      |> assign_new(:sizing_class, fn -> "" end)
+
     ~H"""
-    <div class={"inline-flex bg-#{@color}-500 h-5 px-1 text-sm font-semibold #{@class}"}>
-      <div class="flex items-center justify-center">
-        <p><%= render_slot(@inner_block) %></p>
-      </div>
+    <div class={[
+      "inline-flex align-center justify-center  whitespace-nowrap",
+      @color_class,
+      @font_class,
+      @padding_class,
+      @rounded_class,
+      @sizing_class,
+      @class
+    ]}>
+      <%= render_slot(@inner_block) %>
     </div>
     """
   end

--- a/lib/mbta_metro/components/badge.ex
+++ b/lib/mbta_metro/components/badge.ex
@@ -4,57 +4,35 @@ defmodule MbtaMetro.Components.Badge do
   use Phoenix.Component
 
   attr :class, :string, default: ""
-  attr :color_class, :string, default: "bg-blue-500"
-  attr :font_class, :string, default: "text-sm font-semibold"
-  attr :padding_class, :string
-  attr :rounded_class, :string, default: ""
-  attr :sizing_class, :string
-  attr :type, :string, required: true, values: ["circle", "square"]
+  attr :color, :string, default: "blue-200"
+  attr :variant, :string, default: "square", values: ["circle", "pill", "square"]
 
   slot :inner_block, required: true
 
-  def badge(%{type: "circle"} = assigns) do
-    circle(assigns)
+  def badge(%{variant: "circle"} = assigns) do
+    assigns
+    |> assign(:variant_class, "px-0.5 py-1 w-6 h-6 rounded-full font-semibold")
+    |> base_badge()
   end
 
-  def badge(%{type: "square"} = assigns) do
-    square(assigns)
+  def badge(%{variant: "pill"} = assigns) do
+    assigns
+    |> assign(:variant_class, "px-2 py-1 rounded-full font-semibold")
+    |> base_badge()
   end
 
-  defp circle(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:padding_class, fn -> "px-0.5 py-1" end)
-      |> assign_new(:sizing_class, fn -> "w-6 h-6" end)
+  def badge(%{variant: "square"} = assigns) do
+    assigns
+    |> assign(:variant_class, "px-2 py-1 rounded-md min-w-8 font-bold")
+    |> base_badge()
+  end
 
+  defp base_badge(assigns) do
     ~H"""
     <div class={[
-      "inline-flex rounded-full items-center justify-center whitespace-nowrap",
-      @color_class,
-      @font_class,
-      @padding_class,
-      @sizing_class,
-      @class
-    ]}>
-      <%= render_slot(@inner_block) %>
-    </div>
-    """
-  end
-
-  defp square(assigns) do
-    assigns =
-      assigns
-      |> assign_new(:padding_class, fn -> "px-1" end)
-      |> assign_new(:sizing_class, fn -> "" end)
-
-    ~H"""
-    <div class={[
-      "inline-flex align-center justify-center  whitespace-nowrap",
-      @color_class,
-      @font_class,
-      @padding_class,
-      @rounded_class,
-      @sizing_class,
+      "inline-flex items-center justify-center whitespace-nowrap leading-none text-sm",
+      "bg-#{@color}",
+      @variant_class,
       @class
     ]}>
       <%= render_slot(@inner_block) %>

--- a/lib/mbta_metro/components/badge_stack.ex
+++ b/lib/mbta_metro/components/badge_stack.ex
@@ -23,7 +23,7 @@ defmodule MbtaMetro.Components.BadgeStack do
     <div class="flex -space-x-0.5">
       <.badge
         :for={{[color, text], index} <- Enum.with_index(@badges)}
-        color={color}
+        color_class={color}
         type="circle"
         class={"ring-#{@background} ring-2 #{zindex(index)} #{@class}"}
       >
@@ -38,9 +38,11 @@ defmodule MbtaMetro.Components.BadgeStack do
     <div class="flex -space-x-0.5 h-5 overflow-hidden">
       <%= for {[color, text], index} <- Enum.with_index(@badges) do %>
         <.badge
-          color={color}
+          color_class={color}
+          padding_class="px-2 first:px-2.5"
+          rounded_class="first:rounded-l-sm last:rounded-r-sm"
           type="square"
-          class={"pl-2 pr-2 first:pr-2.5 last:pl-2.5 first:rounded-l-sm last:rounded-r-sm rounded-none #{zindex(index)} #{@class}"}
+          class={"#{zindex(index)} #{@class}"}
         >
           <%= text %>
         </.badge>

--- a/lib/mbta_metro/components/badge_stack.ex
+++ b/lib/mbta_metro/components/badge_stack.ex
@@ -8,23 +8,23 @@ defmodule MbtaMetro.Components.BadgeStack do
   attr :background, :string, default: "white"
   attr :class, :string, default: ""
   attr :badges, :list, required: true
-  attr :type, :string, required: true
+  attr :variant, :string, required: true, values: ["circle", "square"]
 
-  def badge_stack(%{type: "circle"} = assigns) do
+  def badge_stack(%{variant: "circle"} = assigns) do
     circle_stack(assigns)
   end
 
-  def badge_stack(%{type: "square"} = assigns) do
+  def badge_stack(%{variant: "square"} = assigns) do
     square_stack(assigns)
   end
 
   defp circle_stack(assigns) do
     ~H"""
-    <div class="flex -space-x-0.5">
+    <div class="inline-flex -space-x-0.5">
       <.badge
         :for={{[color, text], index} <- Enum.with_index(@badges)}
-        color_class={color}
-        type="circle"
+        variant="circle"
+        color={color}
         class={"ring-#{@background} ring-2 #{zindex(index)} #{@class}"}
       >
         <%= text %>
@@ -35,14 +35,12 @@ defmodule MbtaMetro.Components.BadgeStack do
 
   defp square_stack(assigns) do
     ~H"""
-    <div class="flex -space-x-0.5 h-5 overflow-hidden">
+    <div class="inline-flex -space-x-0.5 h-5 overflow-hidden">
       <%= for {[color, text], index} <- Enum.with_index(@badges) do %>
         <.badge
-          color_class={color}
-          padding_class="px-2 first:px-2.5"
-          rounded_class="first:rounded-l-sm last:rounded-r-sm"
-          type="square"
-          class={"#{zindex(index)} #{@class}"}
+          color={color}
+          variant="square"
+          class={"px-2 first:px-2.5 [&:not(:first-child)]:rounded-l-none [&:not(:last-child)]:rounded-r-none #{zindex(index)} #{@class}"}
         >
           <%= text %>
         </.badge>

--- a/storybook/components/badge.story.exs
+++ b/storybook/components/badge.story.exs
@@ -16,9 +16,17 @@ defmodule Storybook.Components.Badge do
       %Variation{
         id: :circle,
         attributes: %{
-          class: "text-white",
-          color_class: "bg-[#ed8b00]",
-          type: "circle"
+          variant: "circle"
+        },
+        slots: [
+          "7"
+        ]
+      },
+      %Variation{
+        id: :circle_with_customization,
+        attributes: %{
+          class: "text-white !bg-[#ed8b00]",
+          variant: "circle"
         },
         slots: [
           "OL"
@@ -28,10 +36,8 @@ defmodule Storybook.Components.Badge do
         id: :pill,
         attributes: %{
           class: "text-white",
-          color_class: "bg-purple-500",
-          padding_class: "px-2 py-0.5",
-          rounded_class: "rounded-full",
-          type: "square"
+          color: "purple-600",
+          variant: "pill"
         },
         slots: [
           "PURPLE"
@@ -40,9 +46,7 @@ defmodule Storybook.Components.Badge do
       %Variation{
         id: :circle_with_icon,
         attributes: %{
-          class: "text-black",
-          color_class: "bg-blue-100",
-          type: "circle"
+          variant: "circle"
         },
         slots: [
           "<.icon name=\"ship\" class=\"w-4 h-4 fill-black\" />"
@@ -51,31 +55,29 @@ defmodule Storybook.Components.Badge do
       %Variation{
         id: :square,
         attributes: %{
-          class: "min-w-8",
-          color_class: "bg-blue-700 text-orange-100",
-          type: "square"
+          variant: "square"
         },
         slots: [
-          "A"
+          "5 Emails"
         ]
       },
       %Variation{
-        id: :square_with_rounded_corners,
+        id: :square_with_customizations,
         attributes: %{
-          color_class: "bg-yellow-300 text-yellow-900",
-          rounded_class: "rounded-md",
-          type: "square"
+          color: "transparent",
+          class: "text-black border border-2 border-red-800 !rounded-none",
+          variant: "square"
         },
         slots: [
-          "441/442"
+          "Close"
         ]
       },
       %Variation{
         id: :square_with_icon,
         attributes: %{
           class: "shadow-[2px_2px_lightblue]",
-          color_class: "bg-red-800",
-          type: "square"
+          color: "red-400",
+          variant: "square"
         },
         slots: [
           "<.icon type=\"regular\" name=\"heart\" class=\"w-4 h-4 fill-white\" />"

--- a/storybook/components/badge.story.exs
+++ b/storybook/components/badge.story.exs
@@ -17,7 +17,7 @@ defmodule Storybook.Components.Badge do
         id: :circle,
         attributes: %{
           class: "text-white",
-          color: "orange",
+          color_class: "bg-[#ed8b00]",
           type: "circle"
         },
         slots: [
@@ -25,31 +25,56 @@ defmodule Storybook.Components.Badge do
         ]
       },
       %Variation{
+        id: :pill,
+        attributes: %{
+          class: "text-white",
+          color_class: "bg-purple-500",
+          padding_class: "px-2 py-0.5",
+          rounded_class: "rounded-full",
+          type: "square"
+        },
+        slots: [
+          "PURPLE"
+        ]
+      },
+      %Variation{
         id: :circle_with_icon,
         attributes: %{
-          color: "blue",
+          class: "text-black",
+          color_class: "bg-blue-100",
           type: "circle"
         },
         slots: [
-          "<.icon name=\"ship\" class=\"w-4 h-4 fill-white\" />"
+          "<.icon name=\"ship\" class=\"w-4 h-4 fill-black\" />"
         ]
       },
       %Variation{
         id: :square,
         attributes: %{
-          class: "text-yellow-800 rounded-sm",
-          color: "yellow",
+          class: "min-w-8",
+          color_class: "bg-blue-700 text-orange-100",
           type: "square"
         },
         slots: [
-          "86"
+          "A"
+        ]
+      },
+      %Variation{
+        id: :square_with_rounded_corners,
+        attributes: %{
+          color_class: "bg-yellow-300 text-yellow-900",
+          rounded_class: "rounded-md",
+          type: "square"
+        },
+        slots: [
+          "441/442"
         ]
       },
       %Variation{
         id: :square_with_icon,
         attributes: %{
           class: "shadow-[2px_2px_lightblue]",
-          color: "red",
+          color_class: "bg-red-800",
           type: "square"
         },
         slots: [

--- a/storybook/components/badge_stack.story.exs
+++ b/storybook/components/badge_stack.story.exs
@@ -13,24 +13,24 @@ defmodule Storybook.Components.BadgeStack do
         id: :circle,
         attributes: %{
           badges: [
-            ["bg-blue-500", "BL"],
-            ["bg-green-500", "E"],
-            ["bg-orange-500", "OL"],
-            ["bg-red-500", "RL"]
+            ["blue-500", "BL"],
+            ["green-500", "E"],
+            ["orange-500", "OL"],
+            ["red-500", "RL"]
           ],
           class: "text-white",
-          type: "circle"
+          variant: "circle"
         }
       },
       %Variation{
         id: :square,
         attributes: %{
           badges: [
-            ["bg-yellow-400", "90"],
-            ["bg-yellow-400", "105"],
-            ["bg-yellow-400", "93"]
+            ["yellow-300", "90"],
+            ["yellow-300", "105"],
+            ["yellow-300", "93"]
           ],
-          type: "square"
+          variant: "square"
         }
       }
     ]

--- a/storybook/components/badge_stack.story.exs
+++ b/storybook/components/badge_stack.story.exs
@@ -13,10 +13,10 @@ defmodule Storybook.Components.BadgeStack do
         id: :circle,
         attributes: %{
           badges: [
-            ["blue", "BL"],
-            ["green", "E"],
-            ["orange", "OL"],
-            ["red", "RL"]
+            ["bg-blue-500", "BL"],
+            ["bg-green-500", "E"],
+            ["bg-orange-500", "OL"],
+            ["bg-red-500", "RL"]
           ],
           class: "text-white",
           type: "circle"
@@ -26,9 +26,9 @@ defmodule Storybook.Components.BadgeStack do
         id: :square,
         attributes: %{
           badges: [
-            ["yellow", "90"],
-            ["yellow", "105"],
-            ["yellow", "93"]
+            ["bg-yellow-400", "90"],
+            ["bg-yellow-400", "105"],
+            ["bg-yellow-400", "93"]
           ],
           type: "square"
         }


### PR DESCRIPTION
It's not that different from before (`@class` that can be added to), but instead of overriding via `class="default-color-class #{@extra_color_class}"` which doesn't reliably work, we can structure it as..

```
attr :color_class, default: "default-color-class"
```
Such that `<.badge color_class={@extra_color_class} />` actually replaces the default color class (and thus successfully overrides).

> [!NOTE]
> I _could_ have done this for just the one `@class` attribute, but splitting out color/padding/rounding/etc makes it much more consice to change only one of those things and keep all the other defaults. See the added stories for some nice illustrations!

Kept the defaults, save for improving the centering (added `justify-center` to the parent and removed the inner marker), removing default rounding from the square (eh, I should put that back).