### PR TITLE
fix: <.input_group /> styling on mobile

### DIFF
--- a/lib/mbta_metro/components/input_group.ex
+++ b/lib/mbta_metro/components/input_group.ex
@@ -19,17 +19,15 @@ defmodule MbtaMetro.Components.InputGroup do
   def input_group(assigns) do
     ~H"""
     <.fieldset legend={@legend} id={@id} class={@class}>
-      <ul class="p-0 flex flex-col sm:flex-row list-none">
+      <ul class="p-0 flex list-none">
         <li
           :for={{label, value} <- @options}
           class={[
-            "border border-solid border-blue-400 px-3 py-0 text-blue-400 cursor-pointer",
+            "border border-solid border-blue-400 p-0 md:p-1 text-blue-400 cursor-pointer",
             "has-[:checked]:bg-blue-100 has-[:checked]:font-bold",
             "[&:not(:last-child)]:border-r-0",
-            "sm:first:rounded-l-md sm:last:rounded-r-md",
-            "sm:first:rounded-l-md sm:last:rounded-r-md",
-            "max-sm:-mb-px has-[:checked]:max-sm:mb-0",
-            "sm:-mr-px has-[:checked]:sm:mr-0 w-full"
+            "first:rounded-l-md last:rounded-r-md",
+            "w-full"
           ]}
         >
           <.input


### PR DESCRIPTION
# Mobile

## Before
<img width="402" alt="Screenshot 2024-11-29 at 5 35 31 PM" src="https://github.com/user-attachments/assets/f42735c1-7048-417d-b01c-b10829f2a795">

## After

<img width="412" alt="Screenshot 2024-11-29 at 5 31 25 PM" src="https://github.com/user-attachments/assets/761f161c-1c8d-4266-a8aa-8d23dc5d061b">



# Desktop

## Before

<img width="1233" alt="Screenshot 2024-11-29 at 5 35 13 PM" src="https://github.com/user-attachments/assets/b22c667c-ecfc-4574-be5b-90078408f5d9">


## After

<img width="1232" alt="Screenshot 2024-11-29 at 5 31 31 PM" src="https://github.com/user-attachments/assets/39c81b74-65b2-49d2-93be-4984b5fc3340">