### PR TITLE
various small styling fixes

### DIFF
--- a/assets/js/plugins/base.js
+++ b/assets/js/plugins/base.js
@@ -4,11 +4,27 @@ import plugin from "tailwindcss/plugin";
  * Basic styles, CSS resets, etc. for improving cross-browser consistency for
  * the MBTA Metro components
  */
-const basePlugin = plugin(({ addBase }) =>
+const basePlugin = plugin(({ addBase, theme }) =>
   addBase({
     // remove default caret in Safari
     "details > summary::-webkit-details-marker": {
       display: "none"
+    },
+    // the styles from the @tailwindcss/forms plugin aren't customizable, (see
+    // https://github.com/tailwindlabs/tailwindcss/discussions/4645 for
+    // discussion on custom ring color), yet are also too specific and can
+    // override other classes... so we override them as suggested by
+    // https://github.com/tailwindlabs/tailwindcss/discussions/4649#discussioncomment-8714473
+    // to more easily achieve our desired custom focus styles
+    "[type='checkbox'], [type='radio']": {
+      "border-color": theme("colors.cobalt.30"),
+      color: theme("colors.cobalt.30")
+    },
+    "[type='checkbox']:focus, [type='radio']:focus": {
+      "--tw-ring-color": theme("colors.cobalt.60"),
+      "--tw-ring-offset-color": "transparent",
+      "--tw-ring-offset-width": "0px",
+      "border-color": theme("colors.cobalt.30")
     }
   })
 );

--- a/lib/mbta_metro/components/input_group.ex
+++ b/lib/mbta_metro/components/input_group.ex
@@ -16,7 +16,7 @@ defmodule MbtaMetro.Components.InputGroup do
 
   def input_group(assigns) when assigns.type in ~W(checkbox-button radio-button) do
     ~H"""
-    <ul class={"inline-flex p-0 list-none rounded border border-solid border-cobalt-30 text-cobalt-30 divide-x divide-solid divide-cobalt-30 overflow-hidden #{@class}"}>
+    <ul class={"inline-flex p-0 list-none bg-white rounded border border-solid border-cobalt-30 text-cobalt-30 divide-x divide-solid divide-cobalt-30 overflow-hidden #{@class}"}>
       <li
         :for={{label, value} <- @options}
         class={[

--- a/lib/mbta_metro/live/date_picker.ex
+++ b/lib/mbta_metro/live/date_picker.ex
@@ -39,8 +39,8 @@ defmodule MbtaMetro.Live.DatePicker do
     >
       <div id="date-picker-calendar" class="relative">
         <.input type="datetime-local" field={@field} class="w-full" value={nil} data-input />
-        <a href="#" data-toggle class="absolute top-3.5 right-2.5">
-          <.icon name="calendar" type="regular" class="w-4 h-4 fill-cobalt-20" />
+        <a href="#" data-toggle class="absolute top-3.5 right-2.5 leading-none">
+          <.icon name="calendar" type="regular" class="w-4 h-4 fill-cobalt-30" />
         </a>
       </div>
     </div>

--- a/lib/mbta_metro/live/map.ex
+++ b/lib/mbta_metro/live/map.ex
@@ -77,7 +77,7 @@ defmodule MbtaMetro.Live.Map do
             id={"mbta-metro-point-#{index}"}
             type="metro"
             name="point"
-            class="w-4 h-4 fill-cobalt-50"
+            class="w-4 h-4 fill-cobalt-30"
             data-coordinates={Jason.encode!(coordinates)}
           />
         <% end %>
@@ -86,7 +86,7 @@ defmodule MbtaMetro.Live.Map do
             id={"mbta-metro-pin-#{index}"}
             type="metro"
             name={index_to_pin(index)}
-            class="w-16 h-16 fill-cobalt-50"
+            class="w-16 h-16 fill-cobalt-30"
             data-coordinates={Jason.encode!(coordinates)}
           />
         <% end %>

--- a/priv/js/plugins/base.js
+++ b/priv/js/plugins/base.js
@@ -4,11 +4,27 @@ import plugin from "tailwindcss/plugin";
  * Basic styles, CSS resets, etc. for improving cross-browser consistency for
  * the MBTA Metro components
  */
-const basePlugin = plugin(({ addBase }) =>
+const basePlugin = plugin(({ addBase, theme }) =>
   addBase({
     // remove default caret in Safari
     "details > summary::-webkit-details-marker": {
       display: "none"
+    },
+    // the styles from the @tailwindcss/forms plugin aren't customizable, (see
+    // https://github.com/tailwindlabs/tailwindcss/discussions/4645 for
+    // discussion on custom ring color), yet are also too specific and can
+    // override other classes... so we override them as suggested by
+    // https://github.com/tailwindlabs/tailwindcss/discussions/4649#discussioncomment-8714473
+    // to more easily achieve our desired custom focus styles
+    "[type='checkbox'], [type='radio']": {
+      "border-color": theme("colors.cobalt.30"),
+      color: theme("colors.cobalt.30")
+    },
+    "[type='checkbox']:focus, [type='radio']:focus": {
+      "--tw-ring-color": theme("colors.cobalt.60"),
+      "--tw-ring-offset-color": "transparent",
+      "--tw-ring-offset-width": "0px",
+      "border-color": theme("colors.cobalt.30")
     }
   })
 );


### PR DESCRIPTION
- [input group buttons](https://www.figma.com/design/IupfoRXJNItGDD8ZaZCxDz/MBTA-Rider-Design-System-Components?node-id=2490-111&t=PSSLC1uImwhnUVoF-4) should have a white background, not a transparent one
- the datepicker's calendar icon position was slightly off on Dotcom, and it turns out it was being affected by the `line-height `set on Dotcom's `body`. added an explicit line height to counteract that (or any other line-height which might be inherited here). also updated the calendar icon color from black.
- updated the map marker and points to the shade of blue used more widely by the other components
- the checkbox and radio button focus styles were ending up wrong on Dotcom, and as far as I could tell this had to do with the CSS from the Tailwind forms plugin, maybe also involving our usage of `important`.. anyway, I found an alternate approach to customize this style to resemble what we actually want. I tested it out my addition in Dotcom's Tailwind configuration and it worked there.