### PR TITLE
refactor(MixProject): better separation of app/dep

### DIFF
--- a/assets/css/metro.css
+++ b/assets/css/metro.css
@@ -1,0 +1,3 @@
+@import "@mbta/rider-design-system/dist/variables.light.css";
+@import "./default.css";
+@import "./components.css";

--- a/assets/js/styles/content.js
+++ b/assets/js/styles/content.js
@@ -1,5 +1,4 @@
 export default [
-  "node_modules/preline/dist/*.js",
   "../deps/mbta_metro/lib/mbta_metro/components/*.ex",
   "../deps/mbta_metro/lib/mbta_metro/live/*.ex",
-]
+];

--- a/assets/js/styles/plugins.js
+++ b/assets/js/styles/plugins.js
@@ -1,11 +1,6 @@
 import basePlugin from "../plugins/base";
 import buttonPlugin from "../plugins/button";
 
-export default function() {
-  return [
-    require("preline/plugin"),
-    require("@tailwindcss/forms"),
-    basePlugin,
-    buttonPlugin
-  ]
+export default function () {
+  return [require("@tailwindcss/forms"), basePlugin, buttonPlugin];
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -14,8 +14,7 @@
         "camelcase-keys": "9.1.3",
         "date-fns": "4.1.0",
         "flatpickr": "4.6.13",
-        "maplibre-gl": "4.7.0",
-        "preline": "2.4.1"
+        "maplibre-gl": "4.7.0"
       },
       "devDependencies": {
         "@fortawesome/fontawesome-free": "6.6.0"
@@ -222,15 +221,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@tailwindcss/forms": {
@@ -1376,14 +1366,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
       "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw=="
-    },
-    "node_modules/preline": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/preline/-/preline-2.4.1.tgz",
-      "integrity": "sha512-30yx5s2gEOTBWXSTPa+Th23/kGryn9Inhmp9KPzz9G8DZPp9j/LkGyyrSvdsuXh4Clc/sJFLObumFrbI/WmB0w==",
-      "dependencies": {
-        "@popperjs/core": "^2.11.2"
-      }
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -224,16 +224,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -680,20 +670,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -23,8 +23,7 @@
     "camelcase-keys": "9.1.3",
     "date-fns": "4.1.0",
     "flatpickr": "4.6.13",
-    "maplibre-gl": "4.7.0",
-    "preline": "2.4.1"
+    "maplibre-gl": "4.7.0"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "6.6.0"

--- a/assets/tailwind.storybook.config.js
+++ b/assets/tailwind.storybook.config.js
@@ -1,12 +1,18 @@
 const plugin = require("tailwindcss/plugin");
-const {
-  default: MbtaRiderDesignSystemTheme,
-} = require("@mbta/rider-design-system");
-const { content, plugins, safelist } = require("./js/index");
+const { default: MbtaRiderDesignSystemTheme } = require("@mbta/rider-design-system");
+const { content, plugins, safelist } = require("./js/index")
 
 module.exports = {
-  content: [...content, "../lib/mbta_metro/**/*.ex"],
-  safelist: [...safelist],
+  content: [
+    ...content,
+    "../lib/doc_components.ex",
+    "../lib/mbta_metro/**/*.ex",
+    "../storybook/**/*.exs",
+  ],
+  safelist: [
+    ...safelist,
+  ],
+  important: ".mbta-metro-web",
   plugins: [
     ...plugins(),
     // Allows prefixing tailwind classes with LiveView classes to add rules

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -24,7 +24,7 @@ config :mbta_metro, MbtaMetroWeb.Endpoint,
   ]
 
 config :esbuild,
-  version: "0.17.11",
+  version: "0.25.9",
   app: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
@@ -39,7 +39,7 @@ config :esbuild,
   ]
 
 config :tailwind,
-  version: "3.4.0",
+  version: "3.4.17",
   app: [
     args: ~w(
       --config=tailwind.storybook.config.js

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -31,9 +31,10 @@ config :esbuild,
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ],
-  components: [
-    args: ~w(components.css --bundle --outdir=../../priv/static/assets),
-    cd: Path.expand("../assets/css", __DIR__),
+  metro: [
+    args:
+      ~w(js/index.js --bundle --target=es2017 --format=cjs --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
+    cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]
 
@@ -41,9 +42,17 @@ config :tailwind,
   version: "3.4.0",
   app: [
     args: ~w(
-      --config=tailwind.config.js
+      --config=tailwind.storybook.config.js
       --input=css/app.css
       --output=../priv/static/assets/app.css
     ),
+    cd: Path.expand("../assets", __DIR__)
+  ],
+  metro: [
+    args: ~w(
+        --config=tailwind.config.js
+        --input=css/metro.css
+        --output=../priv/static/assets/metro.css
+      ),
     cd: Path.expand("../assets", __DIR__)
   ]

--- a/lib/mix/tasks/mbta_metro/export_assets.ex
+++ b/lib/mix/tasks/mbta_metro/export_assets.ex
@@ -8,34 +8,13 @@ defmodule Mix.Tasks.MbtaMetro.ExportAssets do
   @impl Mix.Task
   def run(_) do
     export_css()
-    export_rider_design_system_files()
     export_fontawesome_icons()
     export_js()
     export_metro_icons()
   end
 
   defp export_css do
-    dir = File.cwd!()
-
-    Esbuild.run(:components, [])
-
-    "cp #{dir}/assets/css/default.css #{dir}/priv/static/assets/default.css"
-    |> Kernel.to_charlist()
-    |> :os.cmd()
-
-    "cat #{dir}/priv/static/assets/components.css >> #{dir}/priv/static/assets/default.css"
-    |> Kernel.to_charlist()
-    |> :os.cmd()
-  end
-
-  defp export_rider_design_system_files do
-    dir = File.cwd!()
-
-    System.cmd("cp", [
-      "-r",
-      "#{dir}/assets/node_modules/@mbta/rider-design-system/dist/.",
-      "#{dir}/priv/static/assets"
-    ])
+    Tailwind.run(:metro, [])
   end
 
   defp export_fontawesome_icons do

--- a/mix.exs
+++ b/mix.exs
@@ -5,6 +5,7 @@ defmodule MbtaMetro.MixProject do
     [
       app: :mbta_metro,
       aliases: aliases(),
+      compilers: Mix.compilers(),
       deps: deps(),
       description: "A Phoenix LiveView component library",
       docs: docs(),
@@ -21,7 +22,7 @@ defmodule MbtaMetro.MixProject do
   #
   # Type `mix help compile.app` for more information.
   def application do
-    if Mix.env() == :dev do
+    if is_metro_app?() do
       [mod: {MbtaMetro.Application, []}]
     else
       []
@@ -34,23 +35,31 @@ defmodule MbtaMetro.MixProject do
     ]
   end
 
+  # If loaded as a dependency, just need the bare minimum to run components
   defp deps do
-    [
-      {:bandit, "~> 1.7", only: :dev, optional: true, runtime: false},
-      {:cva, "~> 0.2"},
-      {:esbuild, "~> 0.10", only: :dev, runtime: Mix.env() == :dev},
-      {:ex_doc, "~> 0.38", only: :dev, runtime: false},
-      {:faker, "~> 0.18", only: :dev, runtime: false},
-      {:floki, "~> 0.38"},
-      {:jason, "~> 1.4"},
-      {:heroicons, "~> 0.5", optional: true},
-      {:phoenix, "~> 1.7"},
-      {:phoenix_live_reload, "~> 1.6", only: :dev, optional: true, runtime: false},
-      {:phoenix_live_view, "~> 1.1"},
-      {:phoenix_storybook, "~> 0.9", only: :dev, optional: true, runtime: Mix.env() == :dev},
-      {:tailwind, "~> 0.3", only: :dev, optional: true, runtime: Mix.env() == :dev},
-      {:timex, "~> 3.7"}
-    ]
+    if is_metro_app?() do
+      [
+        {:bandit, "~> 1.7", only: :dev, optional: true, runtime: false},
+        {:cva, "~> 0.2"},
+        {:esbuild, "~> 0.10", only: :dev, runtime: Mix.env() == :dev},
+        {:ex_doc, "~> 0.38", only: :dev, runtime: false},
+        {:faker, "~> 0.18", only: :dev, runtime: false},
+        {:floki, "~> 0.38"},
+        {:jason, "~> 1.4"},
+        {:heroicons, "~> 0.5", optional: true},
+        {:phoenix, "~> 1.7"},
+        {:phoenix_live_reload, "~> 1.6", only: :dev, optional: true, runtime: false},
+        {:phoenix_live_view, "~> 1.1"},
+        {:phoenix_storybook, "~> 0.9", only: :dev, optional: true, runtime: Mix.env() == :dev},
+        {:tailwind, "~> 0.3"}
+      ]
+    else
+      [
+        {:cva, "~> 0.2"},
+        {:floki, "~> 0.38"},
+        {:jason, "~> 1.4"}
+      ]
+    end
   end
 
   defp docs do
@@ -76,8 +85,8 @@ defmodule MbtaMetro.MixProject do
 
   # We don't want to compile the mbta_metro_web directory when mbta_metro is being run in another app.
   defp elixirc_paths(_) do
-    if Mix.Project.config()[:app] === :mbta_metro do
-      ["lib"]
+    if is_metro_app?() do
+      ["lib", "storybook"]
     else
       [
         "lib/mbta_metro.ex",
@@ -120,5 +129,11 @@ defmodule MbtaMetro.MixProject do
   defp version do
     File.read!("VERSION")
     |> String.trim()
+  end
+
+  # Load different things if this application's a dependency of another project
+  defp is_metro_app? do
+    app = Mix.Project.config()[:app]
+    is_nil(app) or app == :mbta_metro
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule MbtaMetro.MixProject do
   #
   # Type `mix help compile.app` for more information.
   def application do
-    if is_metro_app?() do
+    if is_metro_app?() and Mix.env() != :test do
       [mod: {MbtaMetro.Application, []}]
     else
       []
@@ -41,23 +41,27 @@ defmodule MbtaMetro.MixProject do
       [
         {:bandit, "~> 1.7", only: :dev, optional: true, runtime: false},
         {:cva, "~> 0.2"},
-        {:esbuild, "~> 0.10", only: :dev, runtime: Mix.env() == :dev},
+        {:esbuild, "~> 0.10", runtime: false},
         {:ex_doc, "~> 0.38", only: :dev, runtime: false},
         {:faker, "~> 0.18", only: :dev, runtime: false},
         {:floki, "~> 0.38"},
+        {:gettext, ">= 0.0.0"},
         {:jason, "~> 1.4"},
         {:heroicons, "~> 0.5", optional: true},
         {:phoenix, "~> 1.7"},
         {:phoenix_live_reload, "~> 1.6", only: :dev, optional: true, runtime: false},
         {:phoenix_live_view, "~> 1.1"},
         {:phoenix_storybook, "~> 0.9", only: :dev, optional: true, runtime: Mix.env() == :dev},
-        {:tailwind, "~> 0.3"}
+        {:tailwind, "~> 0.3", runtime: false},
+        {:timex, "~> 3.7"}
       ]
     else
       [
         {:cva, "~> 0.2"},
         {:floki, "~> 0.38"},
-        {:jason, "~> 1.4"}
+        {:gettext, ">= 0.0.0"},
+        {:jason, "~> 1.4"},
+        {:timex, "~> 3.7"}
       ]
     end
   end


### PR DESCRIPTION
My main goal was to make it easier to hook up an application to a local version of Metro via
```elixir
{:mbta_metro, path: "../mbta_metro", app: false}
```
..and have a working setup that we can iterate with. 

I got components working with a fresh Phoenix 1.8 install, since Metro consumers don't care about what version of Phoenix Metro's Storybook needs~

| Normal page | LiveView (showing a LiveComponent) |
|--------|--------|
| <img width="1440" height="1422" alt="image" src="https://github.com/user-attachments/assets/9593195b-ad58-4011-9805-f38a685dc64e" /> | <img width="3198" height="1716" alt="image" src="https://github.com/user-attachments/assets/d7067d4e-7944-4260-872c-a892ead39ad1" /> | 

