### PR TITLE
fix: Only pull in `phoenix_storybook` dependency in `dev` env

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule MbtaMetro.MixProject do
         {:phoenix, "~> 1.8"},
         {:phoenix_live_reload, "~> 1.6", only: :dev, optional: true, runtime: false},
         {:phoenix_live_view, "~> 1.1"},
-        {:phoenix_storybook, "~> 0.9"},
+        {:phoenix_storybook, "~> 0.9", only: :dev, optional: true, runtime: Mix.env() == :dev},
         {:tailwind, "~> 0.3", runtime: false}
       ]
     else


### PR DESCRIPTION
As [part of an earlier deps upgrade](https://github.com/mbta/mbta_metro/commit/2591a60743b0c3967860c9bae97f275ca8e09c43#diff-dfa6f4ed74c90e5d4fda283d547d366586e690387289bcfd473e3fa5f9ace308L62), we got rid of all of the annotations that make `phoenix_storybook` a dev-only dependency, which means that now any consumer of Metro needs to pull in `phoenix_storybook` as well.

This is currently causing Dotcom to be unable to upgrade Metro to version 1.1.1, with this error:
```elixir
Because the lock depends on phoenix_storybook 0.9.2 which depends on phoenix ~> 1.7.0, the lock requires phoenix ~> 1.7.0.
And because your app depends on the lock, phoenix ~> 1.7.0 is required.
So, because your app depends on phoenix 1.8.1, version solving failed.
** (Mix) Hex dependency resolution failed
```

Let's restore `phoenix_storybook` to its previous optional state.