### PR TITLE
fix: Augment attrs for `<.button />` and `<.mode_icon />`

### DIFF
--- a/lib/mbta_metro/components/button.ex
+++ b/lib/mbta_metro/components/button.ex
@@ -5,7 +5,7 @@ defmodule MbtaMetro.Components.Button do
   use CVA.Component
 
   attr :class, :string, default: ""
-  attr :rest, :global
+  attr :rest, :global, include: ["popovertarget"]
 
   slot :inner_block, required: true
 

--- a/lib/mbta_metro/components/system_icons.ex
+++ b/lib/mbta_metro/components/system_icons.ex
@@ -213,7 +213,9 @@ defmodule MbtaMetro.Components.SystemIcons do
   @valid_modes ["subway", "bus", "commuter-rail", "ferry", "the-ride"]
 
   attr :class, :string, default: ""
+  attr :line, :string
   attr :mode, :string, required: true, values: @valid_modes
+  attr :rest, :global
   attr :size, :string, default: "default", values: ["default", "small"]
 
   @doc """
@@ -227,7 +229,13 @@ defmodule MbtaMetro.Components.SystemIcons do
     assigns = assign(assigns, :class, "#{class} #{line_class}")
 
     ~H"""
-    <.icon type="system" class={@class} name={"mode-#{@mode}-#{@size}"} aria-label={label(@mode)} />
+    <.icon
+      type="system"
+      class={@class}
+      name={"mode-#{@mode}-#{@size}"}
+      aria-label={label(@mode)}
+      {@rest}
+    />
     """
   end
 
@@ -235,7 +243,13 @@ defmodule MbtaMetro.Components.SystemIcons do
     assigns = assign(assigns, :class, cva_class(:mode_icon, assigns))
 
     ~H"""
-    <.icon type="system" class={@class} name={"mode-#{@mode}-#{@size}"} aria-label={label(@mode)} />
+    <.icon
+      type="system"
+      class={@class}
+      name={"mode-#{@mode}-#{@size}"}
+      aria-label={label(@mode)}
+      {@rest}
+    />
     """
   end
 


### PR DESCRIPTION
[This Dotcom PR](https://github.com/mbta/dotcom/pull/2804) introduced [a bunch of warnings](https://github.com/mbta/dotcom/actions/runs/19470596826/job/55716527014?pr=2804#step:7:762). Those warnings were actually Metro issues:
- `<.mode_icon />` didn't have a `:rest, :global` attribute defined, which meant that the `aria-hidden` in `<.mode_icon aria-hidden />` was being dropped with a warning. (This is a rider-facing bug, since it means that `<.mode_icon />`'s that you'd think would be hidden from screen readers are still being read out loud)
- `<.mode_icon />` used a `line` attribute, but didn't explicitly declare it as an `attr`, creating a warning for invocations like `<.mode_icon line={...} />`.
- `<.button />` was being invoked with the attribute `popovertarget`, which is valid for buttons, but not for all HTML elements. `attr :rest, :global` [only admits HTML attributes that are valid for all elements](https://github.com/phoenixframework/phoenix_live_view/issues/2292#issuecomment-1287792051), but [does allow additional attributes if specified](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#module-included-globals) in an `include` list.

---

No Ticket.