### PR TITLE
fix: No more `overflow: scroll;` for modals

### DIFF
--- a/assets/css/components/modal.css
+++ b/assets/css/components/modal.css
@@ -7,7 +7,6 @@ dialog.mbta-modal {
   padding: var(--spacing-lg);
   max-height: 100dvh;
   max-width: 65ch; /* "two and a half alphabets" */
-  overflow: scroll;
   z-index: 1000;
 
   form[method="dialog"] {

--- a/priv/dist/metro.css
+++ b/priv/dist/metro.css
@@ -2518,7 +2518,6 @@ dialog.mbta-modal {
   padding: var(--spacing-lg);
   max-height: 100dvh;
   max-width: 65ch;
-  overflow: scroll;
   z-index: 1000;
   form[method=dialog] {
     background-color: var(--colors-cobalt-90);


### PR DESCRIPTION
`overflow: scroll;` was adding funky non-scroll scrollbars to modals.

<img width="695" height="471" alt="Screenshot 2025-11-18 at 2 43 12 PM" src="https://github.com/user-attachments/assets/c3290ace-6420-430b-95bc-be5c0e33a5b4" />


Getting rid of that leads to the default scroll behavior of showing a scrollbar when the content needs it, and omitting it when the content is small enough to fit.

<img width="685" height="448" alt="Screenshot 2025-11-18 at 3 11 30 PM" src="https://github.com/user-attachments/assets/0f18a086-560c-4244-8b9a-7b90fe71645b" />
<img width="656" height="818" alt="Screenshot 2025-11-18 at 3 11 36 PM" src="https://github.com/user-attachments/assets/c5d5d59d-d852-4730-9818-80a433fde98d" />


---

No ticket, but this blocks https://github.com/mbta/dotcom/pull/2798