### PR TITLE
feat(button): add tertiary variant

### DIFF
--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -12,7 +12,7 @@
   padding-top: var(--spacing-sm);
   padding-left: var(--spacing-default);
   padding-right: var(--spacing-default);
-  transition: background-color var(--transition-duration-default) ease;
+  transition: background-color var(--transition-duration) ease;
 
   &[aria-disabled] {
     cursor: not-allowed;

--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -62,3 +62,21 @@
     color: var(--button-secondary-active-text-color);
   }
 }
+
+.mbta-button-tertiary {
+  background-color: var(--button-tertiary-default-background-color);
+  border-color: var(--button-tertiary-default-border-color);
+  color: var(--button-tertiary-default-text-color);
+
+  &:hover {
+    background-color: var(--button-tertiary-hover-background-color);
+    border-color: var(--button-tertiary-hover-border-color);
+    color: var(--button-tertiary-hover-text-color);
+  }
+
+  &:active {
+    background-color: var(--button-tertiary-active-background-color);
+    border-color: var(--button-tertiary-active-border-color);
+    color: var(--button-tertiary-active-text-color);
+  }
+}

--- a/assets/css/components/button.css
+++ b/assets/css/components/button.css
@@ -1,27 +1,25 @@
 .mbta-button {
   align-items: center;
-  border-radius: var(--border-radius-md);
-  border-width: var(--border-width-sm);
+  border-radius: var(--border-radius-default);
+  border-width: var(--border-width-default);
   column-gap: var(--spacing-sm);
   display: inline-flex;
   font-family: var(--font-family-base);
   font-size: var(--font-size-default);
   font-weight: 500;
+  line-height: var(--line-height-default);
   padding-bottom: var(--spacing-sm);
   padding-top: var(--spacing-sm);
-  padding-left: var(--spacing-md);
-  padding-right: var(--spacing-md);
-  transition: all var(--transition-duration-default) ease;
+  padding-left: var(--spacing-default);
+  padding-right: var(--spacing-default);
+  transition: background-color var(--transition-duration-default) ease;
 
   &[aria-disabled] {
-    background-color: var(--colors-charcoal-30);
-    border-color: var(--colors-charcoal-30);
-    color: var(--colors-white);
     cursor: not-allowed;
   }
   &:focus,
   &:focus-within {
-    outline: var(--spacing-xs) solid var(--colors-cobalt-60);
+    outline: var(--spacing-xs) solid var(--colors-focus);
     outline-offset: 0;
   }
 }

--- a/lib/mbta_metro/components/button.ex
+++ b/lib/mbta_metro/components/button.ex
@@ -12,7 +12,8 @@ defmodule MbtaMetro.Components.Button do
   variant :variant,
           [
             primary: "mbta-button mbta-button-primary",
-            secondary: "mbta-button mbta-button-secondary"
+            secondary: "mbta-button mbta-button-secondary",
+            tertiary: "mbta-button mbta-button-tertiary"
           ],
           default: :primary
 
@@ -24,8 +25,14 @@ defmodule MbtaMetro.Components.Button do
           default: :default
 
   @doc """
-  Button styles in primary and secondary variants, and small and regular sizing.
+  Button styles in primary, secondary, and tertiary variants, and small and regular sizing.
   """
+  def button(%{variant: "tertiary", size: "default"} = assigns) do
+    assigns
+    |> assign(:size, "small")
+    |> button()
+  end
+
   def button(assigns) do
     ~H"""
     <button class={"#{@cva_class} #{@class}"} {@rest}>

--- a/priv/dist/metro.css
+++ b/priv/dist/metro.css
@@ -715,6 +715,21 @@ details.mbta-accordion {
     color: var(--button-secondary-active-text-color);
   }
 }
+.mbta-button-tertiary {
+  background-color: var(--button-tertiary-default-background-color);
+  border-color: var(--button-tertiary-default-border-color);
+  color: var(--button-tertiary-default-text-color);
+  &:hover {
+    background-color: var(--button-tertiary-hover-background-color);
+    border-color: var(--button-tertiary-hover-border-color);
+    color: var(--button-tertiary-hover-text-color);
+  }
+  &:active {
+    background-color: var(--button-tertiary-active-background-color);
+    border-color: var(--button-tertiary-active-border-color);
+    color: var(--button-tertiary-active-text-color);
+  }
+}
 
 /* css/components/data_list.css */
 .mbta-data-list {

--- a/priv/dist/metro.css
+++ b/priv/dist/metro.css
@@ -660,27 +660,25 @@ details.mbta-accordion {
 /* css/components/button.css */
 .mbta-button {
   align-items: center;
-  border-radius: var(--border-radius-md);
-  border-width: var(--border-width-sm);
+  border-radius: var(--border-radius-default);
+  border-width: var(--border-width-default);
   column-gap: var(--spacing-sm);
   display: inline-flex;
   font-family: var(--font-family-base);
   font-size: var(--font-size-default);
   font-weight: 500;
+  line-height: var(--line-height-default);
   padding-bottom: var(--spacing-sm);
   padding-top: var(--spacing-sm);
-  padding-left: var(--spacing-md);
-  padding-right: var(--spacing-md);
-  transition: all var(--transition-duration-default) ease;
+  padding-left: var(--spacing-default);
+  padding-right: var(--spacing-default);
+  transition: background-color var(--transition-duration-default) ease;
   &[aria-disabled] {
-    background-color: var(--colors-charcoal-30);
-    border-color: var(--colors-charcoal-30);
-    color: var(--colors-white);
     cursor: not-allowed;
   }
   &:focus,
   &:focus-within {
-    outline: var(--spacing-xs) solid var(--colors-cobalt-60);
+    outline: var(--spacing-xs) solid var(--colors-focus);
     outline-offset: 0;
   }
 }

--- a/priv/dist/metro.css
+++ b/priv/dist/metro.css
@@ -672,7 +672,7 @@ details.mbta-accordion {
   padding-top: var(--spacing-sm);
   padding-left: var(--spacing-default);
   padding-right: var(--spacing-default);
-  transition: background-color var(--transition-duration-default) ease;
+  transition: background-color var(--transition-duration) ease;
   &[aria-disabled] {
     cursor: not-allowed;
   }

--- a/storybook/components/button.story.exs
+++ b/storybook/components/button.story.exs
@@ -80,6 +80,16 @@ defmodule Storybook.Components.Button do
           "Secondary small button"
         ],
         description: "Secondary small button"
+      },
+      %Variation{
+        id: :tertiary,
+        attributes: %{
+          variant: "tertiary"
+        },
+        slots: [
+          "Tertiary button"
+        ],
+        description: "Tertiary button is always small"
       }
     ]
   end


### PR DESCRIPTION
I forgot to do this earlier! See [Figma reference](https://www.figma.com/design/IupfoRXJNItGDD8ZaZCxDz/MBTA-Rider-Design-System-Components?node-id=3506-159&m=dev).
I also updated some of the default button implementation to use default tokens (same values, so shouldn't change any current buttons).
Tertiary buttons are always small, so there's a little logic to ensure it never renders in the default size.