### PR TITLE
feat: Set stroke color for `mbta-route-*`, same as fill color

### DIFF
--- a/assets/css/utilities/routes.css
+++ b/assets/css/utilities/routes.css
@@ -2,46 +2,54 @@
   background-color: var(--colors-brand-bus);
   color: var(--colors-black);
   fill: var(--colors-brand-bus);
+  stroke: var(--colors-brand-bus);
 }
 
 .mbta-route-silver-line {
   background-color: var(--colors-silver-line);
   color: var(--colors-white);
   fill: var(--colors-silver-line);
+  stroke: var(--colors-silver-line);
 }
 
 .mbta-route-commuter-rail {
   background-color: var(--colors-commuter-rail);
   color: var(--colors-white);
   fill: var(--colors-commuter-rail);
+  stroke: var(--colors-commuter-rail);
 }
 
 .mbta-route-ferry {
   background-color: var(--colors-ferry);
   color: var(--colors-white);
   fill: var(--colors-ferry);
+  stroke: var(--colors-ferry);
 }
 
 .mbta-route-green-line {
   background-color: var(--colors-green-line);
   color: var(--colors-white);
   fill: var(--colors-green-line);
+  stroke: var(--colors-green-line);
 }
 
 .mbta-route-orange-line {
   background-color: var(--colors-orange-line);
   color: var(--colors-white);
   fill: var(--colors-orange-line);
+  stroke: var(--colors-orange-line);
 }
 
 .mbta-route-red-line {
   background-color: var(--colors-red-line);
   color: var(--colors-white);
   fill: var(--colors-red-line);
+  stroke: var(--colors-red-line);
 }
 
 .mbta-route-blue-line {
   background-color: var(--colors-blue-line);
   color: var(--colors-white);
   fill: var(--colors-blue-line);
+  stroke: var(--colors-blue-line);
 }

--- a/priv/dist/metro.css
+++ b/priv/dist/metro.css
@@ -2786,41 +2786,49 @@ table.mbta-table {
   background-color: var(--colors-brand-bus);
   color: var(--colors-black);
   fill: var(--colors-brand-bus);
+  stroke: var(--colors-brand-bus);
 }
 .mbta-route-silver-line {
   background-color: var(--colors-silver-line);
   color: var(--colors-white);
   fill: var(--colors-silver-line);
+  stroke: var(--colors-silver-line);
 }
 .mbta-route-commuter-rail {
   background-color: var(--colors-commuter-rail);
   color: var(--colors-white);
   fill: var(--colors-commuter-rail);
+  stroke: var(--colors-commuter-rail);
 }
 .mbta-route-ferry {
   background-color: var(--colors-ferry);
   color: var(--colors-white);
   fill: var(--colors-ferry);
+  stroke: var(--colors-ferry);
 }
 .mbta-route-green-line {
   background-color: var(--colors-green-line);
   color: var(--colors-white);
   fill: var(--colors-green-line);
+  stroke: var(--colors-green-line);
 }
 .mbta-route-orange-line {
   background-color: var(--colors-orange-line);
   color: var(--colors-white);
   fill: var(--colors-orange-line);
+  stroke: var(--colors-orange-line);
 }
 .mbta-route-red-line {
   background-color: var(--colors-red-line);
   color: var(--colors-white);
   fill: var(--colors-red-line);
+  stroke: var(--colors-red-line);
 }
 .mbta-route-blue-line {
   background-color: var(--colors-blue-line);
   color: var(--colors-white);
   fill: var(--colors-blue-line);
+  stroke: var(--colors-blue-line);
 }
 
 /* css/utilities.css */


### PR DESCRIPTION
The CSS classes defined in `routes.css` already set the `fill` property to the color appropriate for the given route. Some shapes are more convenient to define as strokes, rather than filled-in shapes, so it's also helpful to have the default stroke color set to the same route color as well.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213833752592114