### PR TITLE
DatePicker error a11y

### DIFF
--- a/lib/mbta_metro/live/date_picker.ex
+++ b/lib/mbta_metro/live/date_picker.ex
@@ -62,7 +62,11 @@ defmodule MbtaMetro.Live.DatePicker do
           <.icon name="calendar" type="regular" class="mbta-date-picker--icon" />
         </a>
       </div>
-      <.feedback :for={msg <- @errors} kind={:error}>{msg}</.feedback>
+      <.feedback :for={msg <- @errors} kind={:error}>
+        <label for={@field.id} aria-live={true} aria-role="alert">
+          {msg}
+        </label>
+      </.feedback>
     </div>
     """
   end


### PR DESCRIPTION

[♿ Ensure Trip Planner form errors notify screen readers](https://app.asana.com/1/15492006741476/project/555089885850811/task/1211545530335853?focus=true
)
Added label and aria attributes for errors in the datepicker component.

The Metro compliment to this PR: https://github.com/mbta/dotcom/pull/3110